### PR TITLE
Configure Jib for Docker image generation and container run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,26 @@ services:
       POSTGRES_PASSWORD: password
       PGDATA: /data/postgres
     volumes:
-      - postgres:/data/postgres
+      - db:/data/postgres
     ports:
-      - "5432:5432"
+      - "5332:5432"
     networks:
-      - postgres
+      - db
     restart: unless-stopped
+
+  bmerouane-api:
+    container_name: bmerouane-api
+    image: bmeebs/bmerouane-api
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/customer
+    ports:
+      - "8088:8080"
+    networks:
+      - db
+    depends_on:
+      - db
+    restart: unless-stopped
+
   pgadmin:
     container_name: pgadmin
     image: dpage/pgadmin4
@@ -25,15 +39,15 @@ services:
     ports:
       - "5050:80"
     networks:
-      - postgres
+      - db
     restart: unless-stopped
     depends_on:
       - db
 
 networks:
-  postgres:
+  db:
     driver: bridge
 
 volumes:
-  postgres:
+  db:
   pgadmin:

--- a/pom.xml
+++ b/pom.xml
@@ -2,19 +2,24 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.1.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.example</groupId>
-    <artifactId>spring-boot-example</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <name>spring-boot-example</name>
-    <description>Demo project for Spring Boot</description>
+
+    <groupId>com.bmerouane</groupId>
+    <artifactId>bmerouane-api</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <organization>
+        <name>bmerouane</name>
+    </organization>
+
     <properties>
         <java.version>17</java.version>
+        <docker.username>bmeebs</docker.username>
     </properties>
 
     <dependencies>
@@ -105,6 +110,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/*IntegrationTest</exclude>
+                        <exclude>**/*IT.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>
@@ -115,7 +121,7 @@
                     <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                     <includes>
                         <include>**/*IntegrationTest.java</include>
-                        <include>**/IT.java</include>
+                        <include>**/*IT.java</include>
                     </includes>
                     <systemPropertyVariables>
                         <test.server.port>${tomcat.http.port}</test.server.port>
@@ -139,6 +145,32 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>3.4.4</version>
+                <configuration>
+                    <from>
+                        <image>eclipse-temurin:17</image>
+                        <platforms>
+                            <platform>
+                                <architecture>amd64</architecture>
+                                <os>linux</os>
+                            </platform>
+                            <platform>
+                                <architecture>arm64</architecture>
+                                <os>linux</os>
+                            </platform>
+                        </platforms>
+                    </from>
+                    <to>
+                        <image>docker.io/${docker.username}/${project.artifactId}:${project.version}</image>
+                        <tags>
+                            <tag>latest</tag>
+                        </tags>
+                    </to>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ server:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/customer
+    url: jdbc:postgresql://localhost:5332/customer
     username: bmerouane
     password: password
   jpa:


### PR DESCRIPTION
### Summary
This merge request configures the Jib Maven plugin to generate Docker images and run containers for the project.

### Changes
- Added Jib Maven plugin configuration in `pom.xml` to build Docker images.
- Configured the plugin to use the `eclipse-temurin:17` base image.
- Set up multi-platform support for `amd64` and `arm64` architectures.
- Defined the target image repository and tags.
- Updated `docker-compose.yml` to include the `bmerouane-api` service with the correct environment variables and dependencies.